### PR TITLE
Handle failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "gotham",
  "gotham_derive",
  "mime",
+ "rand 0.8.3",
  "reqwest",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ mime = "0.3.16"
 url = "2.1"
 anyhow = "1.0.40"
 simple-error = "0.2.3"
+rand = "0.8.3"
 
 [[bin]]
 name = "crust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::{env, fmt};
 use std::{thread, time::Duration};
 
-const M: u64 = 16384;
+const M: u64 = 64;
 const PORT: usize = 8000;
 
 const HTTP_SUCCESSOR: &str = "successor/";
@@ -23,7 +23,7 @@ const HTTP_FINGER_TABLE: &str = "fingertable/";
 const HTTP_NOTIFY: &str = "notify/";
 
 const STABILIZE_INTERVAL: u64 = 2;
-
+const REQ_TIMEOUT: u64 = 2;
 enum Bracket {
     Open,
     Closed,
@@ -124,6 +124,7 @@ pub struct ChordNode {
     hash_map: Arc<Mutex<HashMap<String, String>>>,
     self_ip: IpAddr,
     predecessor: Arc<Mutex<IpAddr>>,
+    successor_list: Arc<Mutex<Vec<IpAddr>>>,
 }
 
 impl Serialize for ChordNode {
@@ -135,6 +136,11 @@ impl Serialize for ChordNode {
         let self_id = get_identifier(&self.self_ip.to_string());
         let predecessor = self.predecessor.lock().unwrap();
         let predecessor_id = get_identifier(&(*predecessor).to_string());
+        let successor_list = self.successor_list.lock().unwrap();
+        let successor_list: Vec<(&IpAddr, u64)> = successor_list
+            .iter()
+            .map(|ip| (ip, get_identifier(&ip.to_string())))
+            .collect();
 
         let mut state = serializer.serialize_struct("Interval", 4)?;
         state.serialize_field("finger_table", &*finger_table)?;
@@ -143,6 +149,7 @@ impl Serialize for ChordNode {
         state.serialize_field("self_id", &self_id)?;
         state.serialize_field("predecessor", &*predecessor)?;
         state.serialize_field("predecessor_id", &predecessor_id)?;
+        state.serialize_field("successor_list", &*successor_list)?;
         state.end()
     }
 }
@@ -157,11 +164,13 @@ impl ChordNode {
         let finger_table = Arc::new(Mutex::new(finger_table));
         let hash_map = Arc::new(Mutex::new(hash_map));
         let predecessor = Arc::new(Mutex::new(predecessor));
+        let successor_list = Arc::new(Mutex::new(Vec::new()));
         Self {
             finger_table,
             hash_map,
             self_ip,
             predecessor,
+            successor_list,
         }
     }
 
@@ -174,14 +183,18 @@ impl ChordNode {
         (*table).get(0).unwrap().node_ip
     }
 
-    pub fn update_successor(&mut self, new_succ: IpAddr) {
+    pub fn update_successor(&self, new_succ: IpAddr) {
         let mut table = self.finger_table.lock().unwrap();
         let prev_entry = table.get_mut(0).unwrap();
+        let old_id = get_identifier(&prev_entry.node_ip.to_string());
         let new_id = get_identifier(&new_succ.to_string());
-        println!("prev succ: {}", prev_entry.node_ip);
+        println!("prev successor: {} (id:{})", prev_entry.node_ip, old_id);
         (*prev_entry).node_ip = new_succ;
         (*prev_entry).successor = new_id;
-        println!("Updated succ to {} (id:{})", prev_entry.node_ip, new_id);
+        println!(
+            "Updated successor to {} (id:{})",
+            prev_entry.node_ip, new_id
+        );
     }
 
     pub fn get_predecessor(&self) -> IpAddr {
@@ -277,42 +290,59 @@ impl ChordNode {
         Ok(())
     }
 
-    async fn stabilize(&mut self) -> Result<(), HandlerError> {
+    async fn stabilize(&self) -> Result<(), HandlerError> {
+        let client = reqwest::Client::new();
         loop {
-            thread::sleep(Duration::new(STABILIZE_INTERVAL, 0));
+            thread::sleep(Duration::from_secs(STABILIZE_INTERVAL));
             let succ_ip = self.get_successor();
             let successors_predecessor = get_req(succ_ip, HTTP_PREDECESSOR, self).await?;
-            let successors_predecessor_id = get_identifier(&successors_predecessor);
-            let self_id = get_identifier(&self.self_ip.to_string());
-            let succ_id = get_identifier(&succ_ip.to_string());
-            let int_self_to_successor =
-                Interval::new(Bracket::Open, self_id, succ_id, Bracket::Open);
-            if int_self_to_successor.contains(successors_predecessor_id) {
-                println!("stabilize() found a new successor, updating...");
-                self.update_successor(successors_predecessor.parse()?);
-            }
+            if is_node_alive(successors_predecessor.parse()?, Some(&client)).await {
+                let successors_predecessor_id = get_identifier(&successors_predecessor);
+                let self_id = get_identifier(&self.self_ip.to_string());
+                let succ_id = get_identifier(&succ_ip.to_string());
+                let int_self_to_successor =
+                    Interval::new(Bracket::Open, self_id, succ_id, Bracket::Open);
+                if int_self_to_successor.contains(successors_predecessor_id) {
+                    println!("stabilize() found a new successor, updating...");
+                    self.update_successor(successors_predecessor.parse()?);
+                }
 
-            // notify successor about self_ip
-            patch_req(
-                succ_ip,
-                HTTP_NOTIFY,
-                vec![("n", self.self_ip.to_string())],
-                self,
-            )
-            .await?;
+                // notify successor that this node should be their predecessor
+                patch_req(
+                    succ_ip,
+                    HTTP_NOTIFY,
+                    vec![("n", self.self_ip.to_string())],
+                    self,
+                )
+                .await?;
+            }
 
             // fix fingers
             self.fix_fingers().await?;
+
+            // rebuild successor list
+            self.build_successor_list().await?;
         }
     }
 
-    pub fn notify(&self, other_node: IpAddr) {
+    pub async fn notify(&self, other_node: IpAddr) {
         let predecessor = self.get_predecessor();
         let pred_id = get_identifier(&predecessor.to_string());
         let other_id = get_identifier(&other_node.to_string());
         let self_id = get_identifier(&self.self_ip.to_string());
         let int_predecessor_to_self = Interval::new(Bracket::Open, pred_id, self_id, Bracket::Open);
-        if (predecessor == self.self_ip) || (int_predecessor_to_self.contains(other_id)) {
+        let is_predecessor_alive = is_node_alive(predecessor, None).await;
+        if !is_predecessor_alive
+            || (predecessor == self.self_ip)
+            || (int_predecessor_to_self.contains(other_id))
+        {
+            if other_node != predecessor {
+                println!(
+                    "notify found a better predecessor. Updating to {} (id:{})",
+                    other_node,
+                    get_identifier(&other_node.to_string())
+                );
+            }
             self.update_predecessor(other_node);
         }
     }
@@ -338,9 +368,102 @@ impl ChordNode {
         Ok(())
     }
 
+    async fn build_successor_list(&self) -> Result<(), HandlerError> {
+        let m = (M as f64).log2() as u32;
+        let client = reqwest::Client::new();
+        let mut successor = self.get_successor();
+        let mut new_successors = Vec::new();
+        for _ in 0..m {
+            let next_successor = client
+                .get(format!("http://{}:{}/{}", successor, PORT, HTTP_SUCCESSOR))
+                .timeout(Duration::from_secs(REQ_TIMEOUT))
+                .send()
+                .await;
+            match next_successor {
+                Ok(s) => successor = s.text().await?.parse()?,
+                //if a potential successor is down, skip adding it to the list.
+                Err(_) => break,
+            };
+            new_successors.push(successor);
+        }
+        *self.successor_list.lock().unwrap() = new_successors;
+        Ok(())
+    }
+
     async fn handle_failure(&self) {
-        // I REALLY think the return type should be () - let's see how that works out.
-        
+        // check if successor is alive
+        println!("Failure detected, attempting to fix pointers...");
+        let client = reqwest::Client::new();
+        let successor_ip = self.get_successor();
+        let resp = client
+            .get(format!(
+                "http://{}:{}/{}",
+                successor_ip, PORT, HTTP_SUCCESSOR
+            ))
+            .timeout(Duration::from_secs(REQ_TIMEOUT))
+            .send()
+            .await;
+        match resp {
+            Ok(_) => {}
+            Err(_) => {
+                println!("Successor is down. Fixing...");
+                let new_succ = self.get_first_live_successor(&client).await;
+                self.update_successor(new_succ);
+                println!(
+                    "Notifying my new successor (id:{}) to update their predecessor...",
+                    get_identifier(&new_succ.to_string())
+                );
+                client
+                    .patch(format!("http://{}:{}/{}", new_succ, PORT, HTTP_NOTIFY))
+                    .timeout(Duration::from_secs(REQ_TIMEOUT))
+                    .form(&vec![("n", self.self_ip.to_string())])
+                    .send()
+                    .await
+                    .unwrap();
+            }
+        };
+
+        // check if predecessor is alive
+        let predecessor_ip = self.get_predecessor();
+        let resp = client
+            .get(format!(
+                "http://{}:{}/{}",
+                predecessor_ip, PORT, HTTP_SUCCESSOR
+            ))
+            .timeout(Duration::from_secs(REQ_TIMEOUT))
+            .send()
+            .await;
+        match resp {
+            Ok(_) => {}
+            Err(_) => {
+                println!("Predecessor is down. Fixing to self IP.");
+                self.update_predecessor(self.self_ip)
+            }
+        }
+    }
+
+    async fn get_first_live_successor(&self, client: &reqwest::Client) -> IpAddr {
+        let entries: Vec<IpAddr> = {
+            let table = self.successor_list.lock().unwrap();
+            table.iter().map(|ip| *ip).collect()
+        };
+
+        for possible_succ in entries {
+            println!("Trying to contact {}", possible_succ);
+            let resp = client
+                .get(format!(
+                    "http://{}:{}/{}",
+                    possible_succ, PORT, HTTP_SUCCESSOR
+                ))
+                .timeout(Duration::from_secs(REQ_TIMEOUT))
+                .send()
+                .await;
+            match resp {
+                Ok(_) => return possible_succ,
+                Err(_) => continue,
+            }
+        }
+        return self.self_ip;
     }
 }
 
@@ -415,7 +538,7 @@ async fn init_finger_table(
     }
 
     let predecessor = self_ip;
-    println!("Setting my predecessor as me. This will be fixed later by stabilize()");
+    println!("Setting my predecessor as me. This will be fixed later by notify()");
 
     Ok(ChordNode::new(
         finger_table,
@@ -430,7 +553,12 @@ async fn move_keys() -> Result<(), HandlerError> {
 }
 
 async fn get_req(ip: IpAddr, path: &str, chord_node: &ChordNode) -> Result<String, HandlerError> {
-    let resp = reqwest::get(format!("http://{}:{}/{}", ip, PORT, path)).await;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}:{}/{}", ip, PORT, path))
+        .timeout(Duration::from_secs(REQ_TIMEOUT))
+        .send()
+        .await;
     let resp = match resp {
         Ok(resp) => resp,
         Err(e) => {
@@ -439,7 +567,7 @@ async fn get_req(ip: IpAddr, path: &str, chord_node: &ChordNode) -> Result<Strin
         }
     };
     let text = request_unsuccessful(resp, "GET").await?;
-    Ok(text)
+    return Ok(text);
 }
 
 async fn patch_req<T, U>(
@@ -455,6 +583,7 @@ where
     let client = reqwest::Client::new();
     let response = client
         .patch(format!("http://{}:{}/{}", ip, PORT, path))
+        .timeout(Duration::from_secs(REQ_TIMEOUT))
         .form(&data)
         .send()
         .await;
@@ -484,13 +613,41 @@ async fn request_unsuccessful(response: Response, req_type: &str) -> Result<Stri
     Ok(response.text().await?)
 }
 
-pub fn start_stabilize_thread(mut chord_node: ChordNode) {
+async fn is_node_alive(ip: IpAddr, client: Option<&reqwest::Client>) -> bool {
+    let client = match client {
+        Some(client) => client.clone(),
+        None => reqwest::Client::new(),
+    };
+
+    let response = client
+        .get(format!("http://{}:{}/{}", ip, PORT, HTTP_SUCCESSOR))
+        .timeout(Duration::from_secs(REQ_TIMEOUT))
+        .send()
+        .await;
+    match response {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+pub fn start_stabilize_thread(chord_node: ChordNode) {
     thread::spawn(move || {
         tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(chord_node.stabilize())
-            .unwrap();
+            .block_on(err_stabilize(chord_node));
     });
+}
+
+async fn err_stabilize(chord_node: ChordNode) {
+    loop {
+        match chord_node.stabilize().await {
+            Ok(()) => {}
+            Err(e) => eprintln!(
+                "Got error during stabilize, which should be fixed automatically: {:?}",
+                e
+            ),
+        }
+    }
 }
 
 fn get_self_ip() -> IpAddr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,16 @@ use serde_json;
 use simple_error::SimpleError;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::{env, fmt};
 use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, UdpSocket};
 use std::sync::{Arc, Mutex};
+use std::{env, fmt};
 
-const M: u64 = 64;
+const M: u64 = 16384;
 const PORT: usize = 8000;
 
 const HTTP_SUCCESSOR: &str = "successor/";
-const HTTP_SUCCESSOR_CFP: &str = "successor/cfp/";
+const HTTP_SUCCESSOR_CPF: &str = "successor/cpf/";
 const HTTP_PREDECESSOR: &str = "predecessor/";
 const HTTP_FINGER_TABLE: &str = "fingertable/";
 
@@ -59,14 +59,15 @@ impl Interval {
         }
     }
 
-    /// Needs improvement - right now this method uses a pretty inefficient way to check if a `val` lies between an `Interval. Selecting a `start` and and `end` and walking through each value between them isn't ideal, and we need  a faster way to do this.
+    /// todo Needs improvement - right now this method uses a pretty inefficient way to check if a `val` lies between an `Interval. Selecting a `start` and and `end` and walking through each value between them isn't ideal, and we need  a faster way to do this.
     fn contains(&self, val: u64) -> bool {
         let mut start = match self.bracket1 {
             Bracket::Open => (self.val1 + 1) % M,
             Bracket::Closed => self.val1,
         };
+
         let end = match self.bracket2 {
-            Bracket::Open => (self.val2 - 1) % M,
+            Bracket::Open => (self.val2 + M - 1) % M,
             Bracket::Closed => self.val2,
         };
 
@@ -74,13 +75,11 @@ impl Interval {
             if start == val {
                 return true;
             }
-            start += 1;
+            start = (start + 1) % M;
         }
         val == start
     }
 }
-
-#[allow(dead_code)] //todo remove this later
 struct FingerTableEntry {
     start: u64,
     interval: Interval,
@@ -200,15 +199,23 @@ impl ChordNode {
         let mut n_dash = self.self_ip;
         loop {
             let n_dash_id = get_identifier(&n_dash.to_string());
-            let successor = get_req(n_dash, HTTP_SUCCESSOR).await?;
+            let successor = if n_dash == self.self_ip {
+                self.get_successor().to_string()
+            } else {
+                get_req(n_dash, HTTP_SUCCESSOR).await?
+            };
             let successor_hash = get_identifier(&successor);
             let interval = Interval::new(Bracket::Open, n_dash_id, successor_hash, Bracket::Closed);
             if interval.contains(id) {
                 break;
             }
-            n_dash = get_req(n_dash, &format!("{}{}/", HTTP_SUCCESSOR_CFP, id))
-                .await?
-                .parse()?;
+            n_dash = if n_dash == self.self_ip {
+                self.closest_preceding_finger(&id.to_string())
+            } else {
+                get_req(n_dash, &format!("{}{}/", HTTP_SUCCESSOR_CPF, id))
+                    .await?
+                    .parse()?
+            };
         }
 
         Ok(n_dash)
@@ -224,12 +231,44 @@ impl ChordNode {
             Bracket::Open,
         );
         for entry in self.finger_table.lock().unwrap().iter().rev() {
-            println!("Checking if {} is in {}", entry.successor, interval);
             if interval.contains(entry.successor) {
                 return entry.node_ip;
             }
         }
         return self.self_ip;
+    }
+
+    pub async fn update_finger_table(&mut self, s: IpAddr, i: u64) -> Result<(), HandlerError> {
+        let self_id = get_identifier(&self.self_ip.to_string());
+        let s_id = get_identifier(&s.to_string());
+        let ith_ip_id = {
+            let locked_table = self.finger_table.lock().unwrap();
+            (*locked_table).get(i as usize).unwrap().successor.clone()
+        };
+        let interval = Interval::new(Bracket::Closed, self_id, ith_ip_id, Bracket::Open);
+        if interval.contains(s_id) {
+            {
+                let mut lock = self.finger_table.lock().unwrap();
+                let entry = lock.get_mut(i as usize).unwrap();
+                entry.successor = s_id;
+                entry.node_ip = s;
+            }
+            let pred = *self.predecessor.lock().unwrap();
+            let pred_id = get_identifier(&pred.to_string());
+            if pred_id == s_id {
+                println!("Warning: Skipping patching my predecessor because it's the same as s_id! See the README for what this warning means.");
+                return Ok(());
+            }
+            println!("Done. Patching my predecessor ({})", pred_id);
+            patch_req(
+                pred,
+                HTTP_FINGER_TABLE,
+                vec![("n", s.to_string()), ("i", i.to_string())],
+            )
+            .await?;
+        }
+
+        Ok(())
     }
 }
 
@@ -255,7 +294,7 @@ pub fn initialize_node() -> ChordNode {
     } else {
         let node = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(join(self_ip, args[1].parse().unwrap()))
+            .block_on(partial_join(self_ip, args[1].parse().unwrap()))
             .unwrap();
         node
     }
@@ -265,12 +304,13 @@ fn get_start(n: u64, k: u32) -> u64 {
     (n + u64::pow(2, k)) % M
 }
 
-async fn join(self_ip: IpAddr, existing_node: IpAddr) -> Result<ChordNode, HandlerError> {
+async fn partial_join(self_ip: IpAddr, existing_node: IpAddr) -> Result<ChordNode, HandlerError> {
     println!("Initializing my finger tables...");
     let node = init_finger_table(self_ip, existing_node).await?;
     println!("Done.");
-    println!("Skipping updating others' finger tables...");
-    update_others(self_ip, &node).await?;
+    println!("Updating others' finger tables...");
+    update_others(node.self_ip, &node).await?;
+    println!("Done.");
     println!("Skipping moving keys...");
     move_keys().await?;
     Ok(node)
@@ -298,9 +338,8 @@ async fn init_finger_table(
     println!("My predecessor is {}", predecessor);
     patch_req(successor.parse()?, HTTP_PREDECESSOR, vec![("ip", self_ip)]).await?;
     println!("Patched my successor so that its predecessor is me");
-    // patch_req(predecessor.parse()?, HTTP_SUCCESSOR, vec![("ip", self_ip)]).await?;
-    // println!("Patched my predecesssor so that its successor is me");
-    // TODO remove this comment after it's verified that this happens indiretly as a call to update_others().
+    patch_req(predecessor.parse()?, HTTP_SUCCESSOR, vec![("ip", self_ip)]).await?;
+    println!("Patched my predecesssor so that its successor is me");
     let m = (M as f64).log2() as u32;
     for i in 0..m - 1 {
         let start = get_start(self_id, i + 1);
@@ -335,9 +374,19 @@ async fn update_others(self_ip: IpAddr, node: &ChordNode) -> Result<(), HandlerE
     let m = (M as f64).log2() as u32;
     for i in 0..m {
         let self_id = get_identifier(&self_ip.to_string());
-        let prev_id = (self_id - u64::pow(2, i)) % M;
+        let prev_id = (self_id + M - u64::pow(2, i)) % M;
         let p = node.calculate_predecessor(prev_id).await?;
-        patch_req(p, HTTP_FINGER_TABLE, vec![("ip", self_ip)]).await?;
+        if get_identifier(&p.to_string()) == self_id {
+            println!("Warning: Skipping patching my predecessor because it's the same as s_id! See the README for what this warning means.");
+            continue;
+        }
+        println!("Updating predecessor {}'s finger table...", p);
+        patch_req(
+            p,
+            HTTP_FINGER_TABLE,
+            vec![("n", self_ip.to_string()), ("i", i.to_string())],
+        )
+        .await?;
     }
     Ok(())
 }
@@ -372,7 +421,8 @@ async fn request_unsuccessful(response: Response, req_type: &str) -> Result<Stri
     if status != 200 {
         let error = SimpleError::new(format!(
             "Received error from {} req: {}",
-            req_type, response.text().await?
+            req_type,
+            response.text().await?
         ));
         let handler_error = HandlerError::from(error).with_status(status);
         return Err(handler_error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,11 +258,14 @@ pub fn initialize_node() -> ChordNode {
         // first node
         let mut finger_table = FingerTable::new();
         let hash_map = HashMap::new();
-        let start = get_start(self_id, 0);
-        let k_plus_one_start = get_start(self_id, 1);
-        let interval = Interval::new(Bracket::Closed, start, k_plus_one_start, Bracket::Open);
-        let first_entry = FingerTableEntry::new(start, interval, self_id, self_ip);
-        finger_table.add_entry(first_entry);
+        let m = (M as f64).log2() as u32;
+        for i in 0..m{
+            let start = get_start(self_id, i);
+            let k_plus_one_start = get_start(self_id, i+1);
+            let interval = Interval::new(Bracket::Closed, start, k_plus_one_start, Bracket::Open);
+            let first_entry = FingerTableEntry::new(start, interval, self_id, self_ip);
+            finger_table.add_entry(first_entry);
+        }
 
         return ChordNode::new(finger_table, hash_map, self_ip, self_ip);
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::hash::{Hash, Hasher};
 use std::net::{IpAddr, UdpSocket};
 use std::sync::{Arc, Mutex};
 use std::{env, fmt};
+use std::{thread, time::Duration};
 
 const M: u64 = 16384;
 const PORT: usize = 8000;
@@ -18,6 +19,9 @@ const HTTP_SUCCESSOR: &str = "successor/";
 const HTTP_SUCCESSOR_CPF: &str = "successor/cpf/";
 const HTTP_PREDECESSOR: &str = "predecessor/";
 const HTTP_FINGER_TABLE: &str = "fingertable/";
+const HTTP_NOTIFY: &str = "notify/";
+
+const STABILIZE_INTERVAL: u64 = 2;
 
 enum Bracket {
     Open,
@@ -183,7 +187,7 @@ impl ChordNode {
         *self.predecessor.lock().unwrap()
     }
 
-    pub fn update_predecessor(&mut self, ip: IpAddr) {
+    pub fn update_predecessor(&self, ip: IpAddr) {
         *self.predecessor.lock().unwrap() = ip
     }
 
@@ -270,6 +274,37 @@ impl ChordNode {
 
         Ok(())
     }
+
+    async fn stabilize(&mut self) -> Result<(), HandlerError> {
+        loop {
+            thread::sleep(Duration::new(STABILIZE_INTERVAL, 0));
+            println!("Running stabilize...");
+            let succ_ip = self.get_successor();
+            let successors_predecessor = get_req(succ_ip, HTTP_PREDECESSOR).await?;
+            let successors_predecessor_id = get_identifier(&successors_predecessor);
+            let self_id = get_identifier(&self.self_ip.to_string());
+            let succ_id = get_identifier(&succ_ip.to_string());
+            let int_self_to_successor =
+                Interval::new(Bracket::Open, self_id, succ_id, Bracket::Open);
+            if int_self_to_successor.contains(successors_predecessor_id) {
+                self.update_successor(successors_predecessor.parse()?);
+            }
+
+            // notify successor about self_ip
+            patch_req(succ_ip, HTTP_NOTIFY, vec![("n", self.self_ip.to_string())]).await?;
+        }
+    }
+
+    pub fn notify(&self, other_node: IpAddr) {
+        let predecessor = self.get_predecessor();
+        let pred_id = get_identifier(&predecessor.to_string());
+        let other_id = get_identifier(&other_node.to_string());
+        let self_id = get_identifier(&self.self_ip.to_string());
+        let int_predecessor_to_self = Interval::new(Bracket::Open, pred_id, self_id, Bracket::Open);
+        if (predecessor == self.self_ip) || (int_predecessor_to_self.contains(other_id)) {
+            self.update_predecessor(other_node);
+        }
+    }
 }
 
 pub fn initialize_node() -> ChordNode {
@@ -294,7 +329,7 @@ pub fn initialize_node() -> ChordNode {
     } else {
         let node = tokio::runtime::Runtime::new()
             .unwrap()
-            .block_on(partial_join(self_ip, args[1].parse().unwrap()))
+            .block_on(join(self_ip, args[1].parse().unwrap()))
             .unwrap();
         node
     }
@@ -304,12 +339,9 @@ fn get_start(n: u64, k: u32) -> u64 {
     (n + u64::pow(2, k)) % M
 }
 
-async fn partial_join(self_ip: IpAddr, existing_node: IpAddr) -> Result<ChordNode, HandlerError> {
+async fn join(self_ip: IpAddr, existing_node: IpAddr) -> Result<ChordNode, HandlerError> {
     println!("Initializing my finger tables...");
     let node = init_finger_table(self_ip, existing_node).await?;
-    println!("Done.");
-    println!("Updating others' finger tables...");
-    update_others(node.self_ip, &node).await?;
     println!("Done.");
     println!("Skipping moving keys...");
     move_keys().await?;
@@ -321,74 +353,33 @@ async fn init_finger_table(
     existing_node: IpAddr,
 ) -> Result<ChordNode, HandlerError> {
     let self_id = get_identifier(&self_ip.to_string());
-    let start = get_start(self_id, 0);
-    let start_plus_one = get_start(self_id, 1);
-    let interval = Interval::new(Bracket::Closed, start, start_plus_one, Bracket::Open);
-    let successor = get_req(existing_node, &format!("{}{}/", HTTP_SUCCESSOR, start)).await?;
-    println!("My successor is {}", successor);
-    let first_entry = FingerTableEntry::new(
-        start,
-        interval,
-        get_identifier(&successor),
-        successor.parse()?,
-    );
-    let mut finger_table = Vec::new();
-    finger_table.push(first_entry);
-    let predecessor = get_req(successor.parse()?, HTTP_PREDECESSOR).await?;
-    println!("My predecessor is {}", predecessor);
-    patch_req(successor.parse()?, HTTP_PREDECESSOR, vec![("ip", self_ip)]).await?;
-    println!("Patched my successor so that its predecessor is me");
-    patch_req(predecessor.parse()?, HTTP_SUCCESSOR, vec![("ip", self_ip)]).await?;
-    println!("Patched my predecesssor so that its successor is me");
     let m = (M as f64).log2() as u32;
-    for i in 0..m - 1 {
-        let start = get_start(self_id, i + 1);
-        let start_plus_one = get_start(self_id, i + 2);
-        let interval_table = Interval::new(Bracket::Closed, start, start_plus_one, Bracket::Open);
-        let prev_entry = finger_table.get(i as usize).unwrap();
-        let interval_check = Interval::new(
-            Bracket::Closed,
-            self_id,
-            prev_entry.successor,
-            Bracket::Open,
-        );
-        let (succ_ip, succ_id) = if interval_check.contains(start) {
-            (prev_entry.node_ip, prev_entry.successor)
+    let mut finger_table = Vec::new();
+    for i in 0..m {
+        let start = get_start(self_id, i);
+        let start_plus_one = get_start(self_id, i+1);
+        let interval = Interval::new(Bracket::Closed, start, start_plus_one, Bracket::Open);
+        let succ_ip = if i == 0 {
+            let succ_ip = get_req(existing_node, &format!("{}{}/", HTTP_SUCCESSOR, start)).await?;
+            println!("My successor is {}", succ_ip);
+            succ_ip
         } else {
-            let ip = get_req(existing_node, &format!("{}{}", HTTP_SUCCESSOR, start)).await?;
-            (ip.parse()?, get_identifier(&ip))
+            self_ip.to_string()
         };
-        let entry = FingerTableEntry::new(start, interval_table, succ_id, succ_ip);
+        let succ_id = get_identifier(&succ_ip.to_string());
+        let entry = FingerTableEntry::new(start, interval, succ_id, succ_ip.parse()?);
         finger_table.push(entry);
     }
+
+    let predecessor = self_ip;
+    println!("Setting my predecessor as me. This will be fixed later by stabilize()");
 
     Ok(ChordNode::new(
         finger_table,
         HashMap::new(),
         self_ip,
-        predecessor.parse()?,
+        predecessor,
     ))
-}
-
-async fn update_others(self_ip: IpAddr, node: &ChordNode) -> Result<(), HandlerError> {
-    let m = (M as f64).log2() as u32;
-    for i in 0..m {
-        let self_id = get_identifier(&self_ip.to_string());
-        let prev_id = (self_id + M - u64::pow(2, i)) % M;
-        let p = node.calculate_predecessor(prev_id).await?;
-        if get_identifier(&p.to_string()) == self_id {
-            println!("Warning: Skipping patching my predecessor because it's the same as s_id! See the README for what this warning means.");
-            continue;
-        }
-        println!("Updating predecessor {}'s finger table...", p);
-        patch_req(
-            p,
-            HTTP_FINGER_TABLE,
-            vec![("n", self_ip.to_string()), ("i", i.to_string())],
-        )
-        .await?;
-    }
-    Ok(())
 }
 
 async fn move_keys() -> Result<(), HandlerError> {
@@ -428,6 +419,15 @@ async fn request_unsuccessful(response: Response, req_type: &str) -> Result<Stri
         return Err(handler_error);
     }
     Ok(response.text().await?)
+}
+
+pub fn start_stabilize_thread(mut chord_node: ChordNode) {
+    thread::spawn(move || {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(chord_node.stabilize())
+            .unwrap();
+    });
 }
 
 fn get_self_ip() -> IpAddr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use gotham::handler::HandlerError;
 use gotham_derive::StateData;
 use reqwest::Response;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use serde_derive::Serialize;
 use serde_json;
 use simple_error::SimpleError;
 use std::collections::hash_map::DefaultHasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@ impl Serialize for FingerTableEntry {
         let mut state = serializer.serialize_struct("Interval", 4)?;
         state.serialize_field("start", &self.start)?;
         state.serialize_field("interval", &format!("{}", self.interval))?;
-        state.serialize_field("successor", &self.successor)?;
-        state.serialize_field("node_ip", &self.node_ip)?;
+        state.serialize_field("successor_id", &self.successor)?;
+        state.serialize_field("successor", &self.node_ip)?;
 
         state.end()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ async fn update_finger_table(state: &mut State) -> Result<Response<Body>, Handle
         } else if key == "i" {
             i = value;
         } else {
-            let error = SimpleError::new(format!("Invalid key {}, expected key: ip.", key));
+            let error = SimpleError::new(format!("Invalid key {}, expected key: n or i.", key));
             let handler_error = HandlerError::from(error).with_status(StatusCode::BAD_REQUEST);
             return Err(handler_error);
         }
@@ -192,7 +192,6 @@ fn main() {
     let addr = format!("0.0.0.0:{}", PORT);
     println!("Listening for requests at http://{}", addr);
     gotham::start(addr, router(chord));
-    println!("Reached here");
 }
 
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,8 @@ async fn update_successor(state: &mut State) -> Result<Response<Body>, HandlerEr
 /// returns the immediate successor of this node (GET /predecessor/)
 fn get_predecessor(state: State) -> (State, String) {
     let node = ChordNode::borrow_from(&state);
-    let successor = node.get_predecessor();
-    (state, successor.to_string())
+    let predecessor = node.get_predecessor();
+    (state, predecessor.to_string())
 }
 
 async fn update_predecessor(state: &mut State) -> Result<Response<Body>, HandlerError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,13 +94,9 @@ fn closest_preceding_finger(state: State) -> (State, String) {
     (state, res.to_string())
 }
 
-async fn info(state: &mut State) -> Result<Response<Body>, HandlerError>{
+async fn info(state: &mut State) -> Result<Response<Body>, HandlerError> {
     let node = ChordNode::borrow_from(&state);
-    let resp = create_response(
-        &state,
-        StatusCode::OK,
-        mime::APPLICATION_JSON,
-        node.info());
+    let resp = create_response(&state, StatusCode::OK, mime::APPLICATION_JSON, node.info());
     Ok(resp)
 }
 
@@ -122,15 +118,6 @@ fn update_value(_state: State) -> (State, String) {
 /// delete a key value pair (DELETE /key/:key)
 fn delete_value(_state: State) -> (State, String) {
     unimplemented!()
-}
-
-async fn next_node(state: &mut State) -> Result<Response<Body>, HandlerError> {
-    let ip = &PathExtractor::borrow_from(&state).key;
-    println!("ip: {}", ip);
-    let resp = reqwest::get(format!("http://{}:{}/successor/", ip, PORT)).await?;
-    let result = resp.text().await?;
-    let response = create_response(&state, StatusCode::OK, TEXT_PLAIN, result);
-    Ok(response)
 }
 
 fn router(chord: ChordNode) -> Router {
@@ -156,10 +143,6 @@ fn router(chord: ChordNode) -> Router {
             route.patch("/").to_async_borrowing(update_predecessor);
         });
         route.get("/info").to_async_borrowing(info);
-        route
-            .get("/comms/check/:key")
-            .with_path_extractor::<PathExtractor>()
-            .to_async_borrowing(next_node);
 
         route.scope("/key", |route| {
             route.post("/").to(create_value);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,10 @@ use gotham::pipeline::single_middleware;
 use gotham::router::builder::*;
 use gotham::router::Router;
 use gotham::state::{FromState, State};
-use simple_error::SimpleError;
-use url::form_urlencoded;
-
 use mime::TEXT_PLAIN;
+use simple_error::SimpleError;
+use std::net::IpAddr;
+use url::form_urlencoded;
 
 mod extractor;
 use extractor::PathExtractor;
@@ -89,7 +89,7 @@ async fn calculate_successor(state: &mut State) -> Result<Response<Body>, Handle
 fn closest_preceding_finger(state: State) -> (State, String) {
     let node = ChordNode::borrow_from(&state);
     let id = &PathExtractor::borrow_from(&state).key;
-    println!("CFP: Finding CFP for {}", id);
+    println!("cpf: Finding cpf for {}", id);
     let res = node.closest_preceding_finger(id);
     (state, res.to_string())
 }
@@ -98,6 +98,29 @@ async fn info(state: &mut State) -> Result<Response<Body>, HandlerError> {
     let node = ChordNode::borrow_from(&state);
     let resp = create_response(&state, StatusCode::OK, mime::APPLICATION_JSON, node.info());
     Ok(resp)
+}
+async fn update_finger_table(state: &mut State) -> Result<Response<Body>, HandlerError> {
+    let full_body = body::to_bytes(Body::take_from(state)).await?;
+    let data = form_urlencoded::parse(&full_body).into_owned();
+    let mut n = String::new();
+    let mut i = String::new();
+    for (key, value) in data {
+        if key == "n" {
+            n = value;
+        } else if key == "i" {
+            i = value;
+        } else {
+            let error = SimpleError::new(format!("Invalid key {}, expected key: ip.", key));
+            let handler_error = HandlerError::from(error).with_status(StatusCode::BAD_REQUEST);
+            return Err(handler_error);
+        }
+    }
+    let s: IpAddr = n.parse()?;
+    let i: u64 = i.parse()?;
+    let node = state.borrow_mut::<ChordNode>();
+    node.update_finger_table(s, i).await?;
+    let response = create_response(&state, StatusCode::OK, TEXT_PLAIN, "".to_string());
+    Ok(response)
 }
 
 /// add a new key-value pair to the DHT (supplied as POST to /key/)
@@ -134,7 +157,7 @@ fn router(chord: ChordNode) -> Router {
                 .with_path_extractor::<PathExtractor>()
                 .to_async_borrowing(calculate_successor);
             route
-                .get("/cfp/:key")
+                .get("/cpf/:key")
                 .with_path_extractor::<PathExtractor>()
                 .to(closest_preceding_finger);
         });
@@ -143,7 +166,9 @@ fn router(chord: ChordNode) -> Router {
             route.patch("/").to_async_borrowing(update_predecessor);
         });
         route.get("/info").to_async_borrowing(info);
-
+        route
+            .patch("/fingertable")
+            .to_async_borrowing(update_finger_table);
         route.scope("/key", |route| {
             route.post("/").to(create_value);
             route
@@ -162,11 +187,12 @@ fn router(chord: ChordNode) -> Router {
     })
 }
 
-pub fn main() {
+fn main() {
     let chord = initialize_node();
     let addr = format!("0.0.0.0:{}", PORT);
     println!("Listening for requests at http://{}", addr);
-    gotham::start(addr, router(chord))
+    gotham::start(addr, router(chord));
+    println!("Reached here");
 }
 
 mod tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,6 @@ async fn calculate_successor(state: &mut State) -> Result<Response<Body>, Handle
 fn closest_preceding_finger(state: State) -> (State, String) {
     let node = ChordNode::borrow_from(&state);
     let id = &PathExtractor::borrow_from(&state).key;
-    println!("cpf: Finding cpf for {}", id);
     let res = node.closest_preceding_finger(id);
     (state, res.to_string())
 }
@@ -141,7 +140,7 @@ async fn notify(state: &mut State) -> Result<Response<Body>, HandlerError>{
 
     let node = state.borrow::<ChordNode>();
     let response = create_response(&state, StatusCode::OK, TEXT_PLAIN, "".to_string());
-    node.notify(n.parse()?);
+    node.notify(n.parse()?).await;
     Ok(response)
 }
 /// add a new key-value pair to the DHT (supplied as POST to /key/)


### PR DESCRIPTION
This PR adds the function `handle_failure()` which uses the newly added `successor_list` to correctly update the node's `successor` pointer. The method will also check if the `predecessor` of the node is alive, and will update it accordingly if it's found to be dead.